### PR TITLE
Use max frame id as scene length instead of file length

### DIFF
--- a/src/trajdata/dataset_specific/eth_ucy_peds/eupeds_dataset.py
+++ b/src/trajdata/dataset_specific/eth_ucy_peds/eupeds_dataset.py
@@ -211,7 +211,7 @@ class EUPedsDataset(RawDataset):
         scene_data: pd.DataFrame = self.dataset_obj[scene_name]
         scene_location: str = get_location(scene_name)
         scene_split: str = self.metadata.scene_split_map[scene_name]
-        scene_length: int = len(scene_data)
+        scene_length: int = scene_data["frame_id"].max().item() + 1
 
         return Scene(
             self.metadata,


### PR DESCRIPTION
Previously `scene.length_timesteps` would give the total number of rows in the eth dataset. With this fix it instead gives the max. frame id now.