### PR TITLE
Fix scene mode when using the `standardize_data=False`

### DIFF
--- a/examples/scene_batch_example.py
+++ b/examples/scene_batch_example.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from trajdata import AgentBatch, AgentType, UnifiedDataset
+from trajdata import SceneBatch, AgentType, UnifiedDataset
 from trajdata.augmentation import NoiseHistories
 from trajdata.visualization.vis import plot_scene_batch
 
@@ -42,7 +42,7 @@ def main():
         persistent_workers=True,
     )
 
-    batch: AgentBatch
+    batch: SceneBatch
     for batch in tqdm(dataloader):
         plot_scene_batch(batch, batch_idx=0)
 

--- a/src/trajdata/data_structures/batch.py
+++ b/src/trajdata/data_structures/batch.py
@@ -137,7 +137,7 @@ class SceneBatch:
         unique_types: Tensor = torch.unique(self.agent_type)
         return [AgentType(unique_type.item()) for unique_type in unique_types]
 
-    def for_agent_type(self, agent_type: AgentType) -> AgentBatch:
+    def for_agent_type(self, agent_type: AgentType) -> SceneBatch:
         match_type = self.agent_type == agent_type
         return SceneBatch(
             data_idx=self.data_idx[match_type],

--- a/src/trajdata/data_structures/batch_element.py
+++ b/src/trajdata/data_structures/batch_element.py
@@ -353,7 +353,8 @@ class SceneBatchElement:
                 sincos_heading=True,
             )
         else:
-            self.agent_from_world_tf: np.ndarray = np.eye(3)
+            self.centered_agent_from_world_tf: np.ndarray = np.eye(3)
+            self.centered_world_from_agent_tf: np.ndarray = np.eye(3)
 
         ### NEIGHBOR-SPECIFIC DATA ###
         def distance_limit(agent_types: np.ndarray, target_type: int) -> np.ndarray:

--- a/src/trajdata/dataset.py
+++ b/src/trajdata/dataset.py
@@ -580,7 +580,7 @@ class UnifiedDataset(Dataset):
         return self._data_len
 
     # @profile
-    def __getitem__(self, idx: int) -> AgentBatchElement:
+    def __getitem__(self, idx: int) -> Union[SceneBatchElement, AgentBatchElement]:
         scene_path, scene_index_elem = self._data_index[idx]
         if self.centric == "scene":
             scene_info, _, scene_index_elems = UnifiedDataset._get_data_index_scene(


### PR DESCRIPTION
One variable was missing and one wrongly named when using the `standardize_data=False`, which are required here: https://github.com/nvr-avg/trajdata/blob/main/src/trajdata/data_structures/collation.py#L708

Also fixed some missing / wrong types I found while browsing the code. 
